### PR TITLE
Add additional clarification on requestFailed event

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -422,7 +422,8 @@ Emitted when a request fails, for example by timing out.
 
 :::note
 HTTP Error responses, such as 404 or 503, are still successful responses from HTTP standpoint, so request will complete
-with [`event: Page.requestFinished`] event and not with [`event: Page.requestFailed`].
+with [`event: Page.requestFinished`] event and not with [`event: Page.requestFailed`]. A request will only be considered
+failed when the client cannot get a response from the server like net::ERR_FAILED.
 :::
 
 ## event: Page.requestFinished


### PR DESCRIPTION
The current note makes it look like only special responses are considered 'successful' requests, but any request that completes - no matter how - will never show up in the requestFailed event. This tripped me up and I spend over an hour, trying to figure out why it wasn't catching it properly - almost tempted to write a bug report on it.